### PR TITLE
Add dockerfile files for older mongodb versions

### DIFF
--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -1,0 +1,77 @@
+# Pull the base image
+FROM ubuntu:18.04
+
+# Create mongodb user group and user
+RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
+
+# Install various third-party dependencies
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    nano \
+    gnupg \
+    gosu \
+    ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install more locales
+RUN apt-get update \
+  && apt-get install -y locales \
+  && rm -rf /var/lib/apt/lists/* \
+  && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG=en_US.utf8
+
+# Add mongodb public repository
+RUN set -ex; \
+  key='9DA31620334BD75D9DCB49F368818C72E52529D4'; \
+  export GNUPGHOME="$(mktemp -d)"; \
+  ( \
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
+    || gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" \
+    || gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" \
+    || gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" \
+  ); \
+  gpg --batch --export "$key" > /etc/apt/trusted.gpg.d/mongodb.gpg; \
+  gpgconf --kill all; \
+  rm -rf "$GNUPGHOME"; \
+  apt-key list > /dev/null
+
+ENV MONGO_MAJOR=4.0
+ENV MONGO_VERSION=4.0.22
+ENV MONGO_CONFIG_HOME=/etc/mongo
+ENV MONGO_DATA_HOME=/data/db
+
+# Create the data and config folders
+RUN mkdir -p ${MONGO_DATA_HOME} ${MONGO_CONFIG_HOME}
+
+RUN echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/${MONGO_MAJOR} multiverse" | tee /etc/apt/sources.list.d/mongodb-org-${MONGO_MAJOR}.list
+
+# Install mongodb server along with mongos, shell and other tools
+RUN set -x \
+  && ln -s /bin/true /usr/local/bin/systemctl \
+  && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update \
+  && apt-get install -y \
+    mongodb-org=${MONGO_VERSION} \
+    mongodb-org-server=${MONGO_VERSION} \
+    mongodb-org-shell=${MONGO_VERSION} \
+    mongodb-org-mongos=${MONGO_VERSION} \
+    mongodb-org-tools=${MONGO_VERSION} \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -f /usr/local/bin/systemctl \
+  && rm -rf /var/lib/mongodb \
+  && mv /etc/mongod.conf ${MONGO_CONFIG_HOME}/mongod.conf.orig
+
+# Update data and config folder ownerships
+RUN chown -R mongodb:mongodb ${MONGO_DATA_HOME} ${MONGO_CONFIG_HOME}
+
+VOLUME ${MONGO_DATA_HOME}
+
+# Set the container's entry point
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x usr/local/bin/docker-entrypoint.sh \
+  && ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 27017
+CMD ["mongod"]

--- a/4.0/docker-entrypoint.sh
+++ b/4.0/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -eo pipefail
+shopt -s nullglob
+
+# Append any given mongod configuration argument
+if [ "${1:0:1}" = '-' ]; then
+  set -- mongod "$@"
+fi
+
+# Skip if we aren't running mongo related binaries
+if [[ "$1" == mongo* ]]; then
+  echo "Entrypoint script for MongoDB Server ${MONGO_VERSION} started"
+
+  # Change data directory with permissions for mongodb user on running as root
+  if [ "$(id -u)" = "0" ]; then
+    echo "Switching to mongodb user"
+
+    # Update data and config folder ownership
+    find $MONGO_DATA_HOME \! -user mongodb -exec chown mongodb '{}' +
+    find $MONGO_CONFIG_HOME \! -user mongodb -exec chown mongodb '{}' +
+
+    # Make sure we can write to stdout and stderr as mongodb
+    chown --dereference mongodb "/proc/$$/fd/1" "/proc/$$/fd/2" || :
+
+    # Execute mongod or mongos as mongodb user
+    exec gosu mongodb "$BASH_SOURCE" "$@" --bind_ip_all
+  fi
+
+  # Use numactl to start your mongod, config servers and mongos
+  numa='numactl --interleave=all'
+  if $numa true &> /dev/null; then
+    set -- $numa "$@"
+  fi
+fi
+
+exec "$@"

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -1,0 +1,77 @@
+# Pull the base image
+FROM ubuntu:18.04
+
+# Create mongodb user group and user
+RUN groupadd -r mongodb && useradd -r -g mongodb mongodb
+
+# Install various third-party dependencies
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    nano \
+    gnupg \
+    gosu \
+    ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install more locales
+RUN apt-get update \
+  && apt-get install -y locales \
+  && rm -rf /var/lib/apt/lists/* \
+  && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+ENV LANG=en_US.utf8
+
+# Add mongodb public repository
+RUN set -ex; \
+  key='E162F504A20CDF15827F718D4B7C549A058F8B6B'; \
+  export GNUPGHOME="$(mktemp -d)"; \
+  ( \
+    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
+    || gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" \
+    || gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" \
+    || gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" \
+  ); \
+  gpg --batch --export "$key" > /etc/apt/trusted.gpg.d/mongodb.gpg; \
+  gpgconf --kill all; \
+  rm -rf "$GNUPGHOME"; \
+  apt-key list > /dev/null
+
+ENV MONGO_MAJOR=4.2
+ENV MONGO_VERSION=4.2.12
+ENV MONGO_CONFIG_HOME=/etc/mongo
+ENV MONGO_DATA_HOME=/data/db
+
+# Create the data and config folders
+RUN mkdir -p ${MONGO_DATA_HOME} ${MONGO_CONFIG_HOME}
+
+RUN echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/${MONGO_MAJOR} multiverse" | tee /etc/apt/sources.list.d/mongodb-org-${MONGO_MAJOR}.list
+
+# Install mongodb server along with mongos, shell and other tools
+RUN set -x \
+  && ln -s /bin/true /usr/local/bin/systemctl \
+  && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update \
+  && apt-get install -y \
+    mongodb-org=${MONGO_VERSION} \
+    mongodb-org-server=${MONGO_VERSION} \
+    mongodb-org-shell=${MONGO_VERSION} \
+    mongodb-org-mongos=${MONGO_VERSION} \
+    mongodb-org-tools=${MONGO_VERSION} \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -f /usr/local/bin/systemctl \
+  && rm -rf /var/lib/mongodb \
+  && mv /etc/mongod.conf ${MONGO_CONFIG_HOME}/mongod.conf.orig
+
+# Update data and config folder ownerships
+RUN chown -R mongodb:mongodb ${MONGO_DATA_HOME} ${MONGO_CONFIG_HOME}
+
+VOLUME ${MONGO_DATA_HOME}
+
+# Set the container's entry point
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x usr/local/bin/docker-entrypoint.sh \
+  && ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 27017
+CMD ["mongod"]

--- a/4.2/docker-entrypoint.sh
+++ b/4.2/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -eo pipefail
+shopt -s nullglob
+
+# Append any given mongod configuration argument
+if [ "${1:0:1}" = '-' ]; then
+  set -- mongod "$@"
+fi
+
+# Skip if we aren't running mongo related binaries
+if [[ "$1" == mongo* ]]; then
+  echo "Entrypoint script for MongoDB Server ${MONGO_VERSION} started"
+
+  # Change data directory with permissions for mongodb user on running as root
+  if [ "$(id -u)" = "0" ]; then
+    echo "Switching to mongodb user"
+
+    # Update data and config folder ownership
+    find $MONGO_DATA_HOME \! -user mongodb -exec chown mongodb '{}' +
+    find $MONGO_CONFIG_HOME \! -user mongodb -exec chown mongodb '{}' +
+
+    # Make sure we can write to stdout and stderr as mongodb
+    chown --dereference mongodb "/proc/$$/fd/1" "/proc/$$/fd/2" || :
+
+    # Execute mongod or mongos as mongodb user
+    exec gosu mongodb "$BASH_SOURCE" "$@" --bind_ip_all
+  fi
+
+  # Use numactl to start your mongod, config servers and mongos
+  numa='numactl --interleave=all'
+  if $numa true &> /dev/null; then
+    set -- $numa "$@"
+  fi
+fi
+
+exec "$@"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ## Supported tags and respective `Dockerfile` links
  * [4.4, latest](https://github.com/tzeikob/replica/blob/main/4.4/Dockerfile)
+ * [4.2](https://github.com/tzeikob/replica/blob/main/4.2/Dockerfile)
+ * [4.0](https://github.com/tzeikob/replica/blob/main/4.0/Dockerfile)
 
 ## Quick reference (cont.)
  * Where to file issues: [bug tracker](https://github.com/tzeikob/replica/issues)


### PR DESCRIPTION
This PR add docker build files to support older mongodb versions 4.0 and 4.2:

- Duplicate dockerfile and entrypoint script for older mongodb versions
- Update versions and public keys for each version